### PR TITLE
stream_get_line bug

### DIFF
--- a/src/Socket/Beanstalk.php
+++ b/src/Socket/Beanstalk.php
@@ -204,7 +204,7 @@ class Socket_Beanstalk {
 			}
 			$packet = rtrim($data, "\r\n");
 		} else {
-			$packet = stream_get_line($this->_connection, 16384, "\r\n");
+			$packet = trim(fgets($this->_connection, 16384));
 		}
 		return $packet;
 	}


### PR DESCRIPTION
We encountered a bug using stream_get_line where when doing very fast loops, it would get stuck waiting and the loop would stop. In our case, we had the need to empty queues, and would do a `$job = $beanstalk->reserve(1);` followed immediately by a `$beanstalk->delete($job['id']);` until the queue was empty.

fgets+trim may be slightly slower, but it fixed the issue for us.

Server Details:
PHP 5.3.3 (cli)
Linux 2.6.32-279.14.1.el6.x86_64 #1 SMP Tue Nov 6 23:43:09 UTC 2012 x86_64
