### PR TITLE
Fix configuration options bug

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -85,7 +85,7 @@ class Client {
 			'timeout' => 1,
 			'logger' => null
 		];
-		$this->_config = $config + $defaults;
+		$this->_config = array_merge($defaults, $config);
 	}
 
 	/**


### PR DESCRIPTION
Its a bug with providing configuration options
```

Interactive mode enabled
php > $a = ['a' => 1, 'b' => 2];
php > $b = ['b' => 3, 'c' => 4];
php > print_r($a+$b);
Array
(
    [a] => 1
    [b] => 2
    [c] => 4
)
php > print_r(array_merge($a, $b));
Array
(
    [a] => 1
    [b] => 3
    [c] => 4
)
```